### PR TITLE
Add: deploy prod flow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,31 @@
+name: "Deploy Production"
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+env:
+  APP_NAME: "gitops-frontend"
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: "Build and push container"
+        run: |-
+          IMAGE_TAG="${GITHUB_REF#refs/*/}"
+
+          IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:${IMAGE_TAG}"
+
+          docker build -t "${IMAGE_NAME}" .
+          docker push "${IMAGE_NAME}"

--- a/docker/prod.Dockerfile
+++ b/docker/prod.Dockerfile
@@ -1,0 +1,23 @@
+# Dockerfile for Frontend
+
+# Build Stage
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# Install pnpm
+COPY package.json  ./
+COPY package-lock.json ./
+RUN npm install --frozen-lockfile
+COPY . . 
+RUN npm run build
+
+# Production Stage
+FROM nginx:alpine AS runner
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy necessary project files
+COPY --from=builder /app/build /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name localhost;
+
+  root /usr/share/nginx/html;
+
+  # สำหรับเสิร์ฟไฟล์ static จาก build folder
+  location / {
+    try_files $uri /index.html;   # ถ้าไม่พบไฟล์ ให้ fallback ไปที่ index.html
+  }
+}


### PR DESCRIPTION
This pull request includes several changes to set up the production deployment pipeline and configure the Docker and Nginx environments for the `gitops-frontend` application. The main updates involve creating a GitHub Actions workflow for deployment, adding a Dockerfile for production, and configuring Nginx to serve the built application.

Deployment pipeline setup:

* [`.github/workflows/deploy-prod.yml`](diffhunk://#diff-4ce342fb97e7d7feb8a578c91ba89fe4c27ddf16b4306909fe6d90220141913dR1-R31): Added a new GitHub Actions workflow to build and push Docker images on tag pushes. This includes steps for checking out the code, logging into Docker Hub, and building and pushing the Docker image.

Docker configuration:

* [`docker/prod.Dockerfile`](diffhunk://#diff-68a3ad5bfc5625b54392b5db3d1d251e5daaabf09fb569e2593a9fd4c231904dR1-R23): Created a multi-stage Dockerfile for building and running the `gitops-frontend` application. The first stage uses `node:22-alpine` to build the application, and the second stage uses `nginx:alpine` to serve the built application.

Nginx configuration:

* [`nginx.conf`](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR1-R11): Configured Nginx to serve the static files from the build folder and handle fallback routing for single-page application (SPA) by redirecting all requests to `index.html` if the file is not found.