### PR TITLE
Fix: wrong Dockerfile path

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,5 +27,5 @@ jobs:
 
           IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ env.APP_NAME }}:${IMAGE_TAG}"
 
-          docker build -t "${IMAGE_NAME}" .
+          docker build -f docker/prod.Dockerfile -t "${IMAGE_NAME}" .
           docker push "${IMAGE_NAME}"


### PR DESCRIPTION
This pull request includes a small but important change to the deployment workflow configuration. The change specifies a different Dockerfile for the production build.

* [`.github/workflows/deploy-prod.yml`](diffhunk://#diff-4ce342fb97e7d7feb8a578c91ba89fe4c27ddf16b4306909fe6d90220141913dL30-R30): Modified the `docker build` command to use `docker/prod.Dockerfile` instead of the default Dockerfile.